### PR TITLE
Update README as Python 3.9 and newer are supported for VTK

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ pip install git+https://github.com/GuignardLab/napari-sc3D-viewer.git
 
 #### Installation of the surface computation module
 
-To install the surface computation enabled version it is necessary to use Python 3.9 (until [VTK] is ported to Python 3.10) and you can run one of the following commands:
+To install the surface computation enabled version you can run one of the following commands:
 
 ```shell
 pip install '.[pyvista]'


### PR DESCRIPTION
VTK now supports up to Python 3.12 according to PyPI at [PyPI - vtk](https://pypi.org/project/vtk/9.3.0/#files).